### PR TITLE
Fixed broken URL to datestamps.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 
 Per default, date2name gets the modification time of matching files
 and directories and adds a datestamp in standard ISO 8601+ format
-YYYY-MM-DD (http://datestamp.org/index.shtml) at the beginning of
+YYYY-MM-DD (http://datestamps.org/index.shtml) at the beginning of
 the file- or directoryname.
 
 If an existing timestamp is found, its style will be converted to the

--- a/date2name
+++ b/date2name
@@ -42,7 +42,7 @@ USAGE = "\n\
 \n\
 Per default, %prog gets the modification time of matching files\n\
 and directories and adds a datestamp in standard ISO 8601+ format\n\
-YYYY-MM-DD (http://datestamp.org/index.shtml) at the beginning of\n\
+YYYY-MM-DD (http://datestamps.org/index.shtml) at the beginning of\n\
 the file- or directoryname.\n\
 If an existing timestamp is found, its style will be converted to the\n\
 selected ISO datestamp format but the numbers stays the same.\n\

--- a/date2name.1.txt
+++ b/date2name.1.txt
@@ -13,7 +13,7 @@ Introduction
 ------------
 
 date2name adds ISO 8601+ compatible datestamps (YYYY-MM-DD,
-link:http://datestamp.org/index.shtml[ISO 8601+ webpage]) to file- and
+link:http://datestamps.org/index.shtml[ISO 8601+ webpage]) to file- and
 directorynames or converts datestamps between known datestamp formats.
 
 Per default, date2name uses the modification time of matching files and


### PR DESCRIPTION
I found that the link datestamp.org did not work, but changing to datestamp**s**.org seemed to fix it.