### PR TITLE
completion file testing, date2name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # GNU Make file for the automation of pytest for date2name.
 #
 # While the test script is written for Python 3.9.2, you might need to
-# adjust the following instruction once in case your OS includes pyest
+# adjust the following instruction once in case your OS includes pytest
 # for legacy Python 2 side by side to Python 3, or only hosts pytest
 # for Python 3.  The tests in script test_date2name.py are set up to
 # work with pytest for Python 3; dependent on your installation, which

--- a/README.org
+++ b/README.org
@@ -32,6 +32,7 @@ Run "date2name --help" for usage hints such as:
 :   -h, --help         show the extended help message and exit
 :   -d, --directories  modify only directory names
 :   -f, --files        modify only file names
+:   -S, --short        use short datestamp               (YYMMDD)
 :   -C, --compact      use compact datestamp             (YYYYMMDD)
 :   -M, --month        use datestamp with year and month (YYYY-MM)
 :   -w, --withtime     use datestamp including seconds   (YYYY-MM-DDThh.mm.ss)

--- a/test_date2name.py
+++ b/test_date2name.py
@@ -4,7 +4,7 @@
 # author:  nbehrnd@yahoo.com
 # license: GPL v3, 2021.
 # date:    2021-08-30 (YYYY-MM-DD)
-# edit:    2021-09-02 (YYYY-MM-DD)
+# edit:    2021-09-17 (YYYY-MM-DD)
 #
 """Test pad for functions by date2name with pytest.
 
@@ -62,7 +62,7 @@ def test_create_remove_testfile():
     os.remove(TFILE)
 
 
-def test_script_existance():
+def test_script_existence():
     """Merely check for the script's presence."""
     assert os.path.isfile(PROGRAM)
 
@@ -78,7 +78,7 @@ def test_script_version():
                                   "-m", "--mtime",
                                   "-c", "--ctime"])
 def test_default_pattern_YYYY_MM_DD(arg1):
-    """Prepend YYYY-MM-DD to the file."""
+    """Prepend 'YYYY-MM-DD_' to the file name."""
     prepare_testfile()
     day = str("")
     new = str("")
@@ -102,7 +102,7 @@ def test_default_pattern_YYYY_MM_DD(arg1):
                                   "-C -c", "--compact -c",
                                   "-C --ctime", "--compact --ctime"])
 def test_compact_pattern_YYYYMMDD(arg1):
-    """Prepend YYYYMMDD to the file."""
+    """Prepend 'YYYYMMDD_' to the file name."""
     prepare_testfile()
     day = str("")
     new = str("")
@@ -133,8 +133,8 @@ def test_compact_pattern_YYYYMMDD(arg1):
                                   "-M --mtime", "--month --mtime",
                                   "-M -c", "--month -c",
                                   "-M --ctime", "--month --ctime"])
-def test_compact_monthn_YYYY_MM(arg1):
-    """Prepend YYYY-MM to the file."""
+def test_compact_month_YYYY_MM(arg1):
+    """Prepend 'YYYY-MM_' to the file name."""
     prepare_testfile()
     day = str("")
     new = str("")
@@ -165,7 +165,7 @@ def test_compact_monthn_YYYY_MM(arg1):
                                   "-w -c", "-w --ctime",
                                   "--withtime -c", "--withtime --ctime"])
 def test_default_pattern_YYYY_MM_DDThh_mm_ss(arg1):
-    """Prepend YYYY-MM-DDThh.mm.ss to the file."""
+    """Prepend 'YYYY-MM-DDThh.mm.ss_' to the file name."""
     prepare_testfile()
     day = str("")
     new = str("")
@@ -183,7 +183,7 @@ def test_default_pattern_YYYY_MM_DDThh_mm_ss(arg1):
         second = query_file_creation().split()[1]
 
     second = second.split(".")[0]  # use integer seconds only
-    second = second.replace(":", ".")  # adjust represetation
+    second = second.replace(":", ".")  # adjust representation
 
     new = "".join([day, "T", second, "_", TFILE])
 

--- a/test_date2name.py
+++ b/test_date2name.py
@@ -118,7 +118,7 @@ def test_compact_pattern_YYYYMMDD(arg1):
                   "-C --ctime", "--compact --ctime"]:
         day = query_file_creation().split()[0]
 
-    # drop the hyphens in the date stamp:
+    # drop the hyphens in the datestamp:
     day = day.replace("-", "")
 
     new = "_".join([day, TFILE])
@@ -150,7 +150,7 @@ def test_compact_month_YYYY_MM(arg1):
                   "-M --ctime", "--month --ctime"]:
         day = query_file_creation().split()[0]
 
-    # trim off the last three characters in the date stamp:
+    # trim off the last three characters in the datestamp:
     day = day[:-3]
 
     new = "_".join([day, TFILE])
@@ -187,6 +187,40 @@ def test_default_pattern_YYYY_MM_DDThh_mm_ss(arg1):
 
     new = "".join([day, "T", second, "_", TFILE])
 
+    test = getoutput(f"python3 {PROGRAM} {TFILE} {arg1}")
+    assert os.path.isfile(new)
+    os.remove(new)
+
+@pytest.mark.parametrize("arg1", ["-S", "--short",
+                                  "-S -f", "--short -f",
+                                  "-S --files", "--short --files",
+                                  "-S -m", "--short -m",
+                                  "-S --mtime", "--short --mtime",
+                                  "-S -c", "--short -c",
+                                  "-S --ctime", "--short --ctime"])
+def test_short_pattern_YYMMDD(arg1):
+    """Prepend 'YYMMDD_' to the file name."""
+    prepare_testfile()
+    day = str("")
+    new = str("")
+
+    if arg1 in ["-S", "--short",
+                "-S -f", "--short -f",
+                "-S --files", "--short --files",
+                "-S -m", "--short -m",
+                "-S --mtime", "--short --mtime"]:
+        day = query_file_modification().split()[0]
+
+    elif arg1 in ["-S -c", "--short -c",
+                  "-S --ctime", "--short --ctime"]:
+        day = query_file_creation().split()[0]
+
+    # drop the hyphens in the datestamp:
+    day = day.replace("-", "")
+    # drop the first two characters about the year (e.g., 1789 -> 89)
+    day = day[2:]
+
+    new = "_".join([day, TFILE])
     test = getoutput(f"python3 {PROGRAM} {TFILE} {arg1}")
     assert os.path.isfile(new)
     os.remove(new)

--- a/test_generator.org
+++ b/test_generator.org
@@ -1,6 +1,6 @@
 #+NAME:    test_generator.org
 #+AUTHOR:  nbehrnd@yahoo.com
-#+DATE:    2021-09-02 (YYYY-MM-DD)
+#+DATE:    2021-09-17 (YYYY-MM-DD)
 # License: GPL3, 2021.
 
 #+PROPERTY: header-args :tangle yes
@@ -8,7 +8,7 @@
 
 * Intent
 
-  The application =date2name= by Karl Voit /et al./ ([[https://github.com/novoid/date2name][source)]] prepepends date
+  The application =date2name= by Karl Voit /et al./ ([[https://github.com/novoid/date2name][source)]] prepends date
   stamps to files and folders (YYYY-MM-DD, YYYYMMDD, YYYY-MM, and
   YYYY-MM-DDThh.mm.ss).  This Emacs .org file is used to prepare the automatic
   testing of the file processing by [[https://docs.pytest.org/en/latest/][pytest]].
@@ -19,7 +19,7 @@
   library, but may be obtained easily e.g., from [[https://pypi.org/project/pytest/][PyPi]].
 
   It is advantageous to retain the options to run =pytest= in a =Makefile=,
-  which equally is inlcuded in this development e.g. to retain if an
+  which equally is included in this development e.g. to retain if an
   instruction like =pytest -xv= or =pytest-3 -xv= is necessary (/vide infra/).
 
 * Dependencies
@@ -60,7 +60,7 @@
       # GNU Make file for the automation of pytest for date2name.
       #
       # While the test script is written for Python 3.9.2, you might need to
-      # adjust the following instruction once in case your OS includes pyest
+      # adjust the following instruction once in case your OS includes pytest
       # for legacy Python 2 side by side to Python 3, or only hosts pytest
       # for Python 3.  The tests in script test_date2name.py are set up to
       # work with pytest for Python 3; dependent on your installation, which
@@ -90,7 +90,7 @@
       # author:  nbehrnd@yahoo.com
       # license: GPL v3, 2021.
       # date:    2021-08-30 (YYYY-MM-DD)
-      # edit:    2021-09-02 (YYYY-MM-DD)
+      # edit:    2021-09-17 (YYYY-MM-DD)
       #
       """Test pad for functions by date2name with pytest.
       
@@ -162,7 +162,7 @@
           os.remove(TFILE)
 
 
-      def test_script_existance():
+      def test_script_existence():
           """Merely check for the script's presence."""
           assert os.path.isfile(PROGRAM)
 
@@ -178,15 +178,15 @@
 
 *** perform the tests on files [4/4]
 
-    These are tests for prepending the time stamp to a file name without
-    explicit call to query for the time of modification.
+    These tests check the addition of a time stamp ahead of the file name.
+
     + [X] default pattern, i.e. prepend YYYY-MM-DD_ to file test.txt
       #+begin_src python :tangle test_date2name.py
         @pytest.mark.parametrize("arg1", [" ", "-f", "--files",
                                           "-m", "--mtime",
                                           "-c", "--ctime"])
         def test_default_pattern_YYYY_MM_DD(arg1):
-            """Prepend YYYY-MM-DD to the file."""
+            """Prepend 'YYYY-MM-DD_' to the file name."""
             prepare_testfile()
             day = str("")
             new = str("")
@@ -215,7 +215,7 @@
                                           "-C -c", "--compact -c",
                                           "-C --ctime", "--compact --ctime"])
         def test_compact_pattern_YYYYMMDD(arg1):
-            """Prepend YYYYMMDD to the file."""
+            """Prepend 'YYYYMMDD_' to the file name."""
             prepare_testfile()
             day = str("")
             new = str("")
@@ -251,8 +251,8 @@
                                           "-M --mtime", "--month --mtime",
                                           "-M -c", "--month -c",
                                           "-M --ctime", "--month --ctime"])
-        def test_compact_monthn_YYYY_MM(arg1):
-            """Prepend YYYY-MM to the file."""
+        def test_compact_month_YYYY_MM(arg1):
+            """Prepend 'YYYY-MM_' to the file name."""
             prepare_testfile()
             day = str("")
             new = str("")
@@ -287,7 +287,7 @@
                                           "-w -c", "-w --ctime",
                                           "--withtime -c", "--withtime --ctime"])
         def test_default_pattern_YYYY_MM_DDThh_mm_ss(arg1):
-            """Prepend YYYY-MM-DDThh.mm.ss to the file."""
+            """Prepend 'YYYY-MM-DDThh.mm.ss_' to the file name."""
             prepare_testfile()
             day = str("")
             new = str("")
@@ -305,7 +305,7 @@
                 second = query_file_creation().split()[1]
 
             second = second.split(".")[0]  # use integer seconds only
-            second = second.replace(":", ".")  # adjust represetation
+            second = second.replace(":", ".")  # adjust representation
 
             new = "".join([day, "T", second, "_", TFILE])
 

--- a/test_generator.org
+++ b/test_generator.org
@@ -8,10 +8,10 @@
 
 * Intent
 
-  The application =date2name= by Karl Voit /et al./ ([[https://github.com/novoid/date2name][source)]] prepends date
-  stamps to files and folders (YYYY-MM-DD, YYYYMMDD, YYYY-MM, and
-  YYYY-MM-DDThh.mm.ss).  This Emacs .org file is used to prepare the automatic
-  testing of the file processing by [[https://docs.pytest.org/en/latest/][pytest]].
+  The application =date2name= by Karl Voit /et al./ ([[https://github.com/novoid/date2name][source)]] prepends datestamps
+  to files and folders (YYYY-MM-DD, YYYYMMDD, YYYY-MM, and YYYY-MM-DDThh.mm.ss).
+  This Emacs .org file is used to prepare the automatic testing of the file
+  processing by [[https://docs.pytest.org/en/latest/][pytest]].
 
   By the command =C-c C-v t=, this =.org= file may (re)generate the tangled test
   script, file =test_date2name.py= as well as a dedicated =Makefile= to ease the
@@ -176,7 +176,7 @@
     #+end_src
 
 
-*** perform the tests on files [4/4]
+*** perform the tests on files [5/5]
 
     These tests check the addition of a time stamp ahead of the file name.
 
@@ -231,7 +231,7 @@
                           "-C --ctime", "--compact --ctime"]:
                 day = query_file_creation().split()[0]
 
-            # drop the hyphens in the date stamp:
+            # drop the hyphens in the datestamp:
             day = day.replace("-", "")
 
             new = "_".join([day, TFILE])
@@ -268,7 +268,7 @@
                           "-M --ctime", "--month --ctime"]:
                 day = query_file_creation().split()[0]
 
-            # trim off the last three characters in the date stamp:
+            # trim off the last three characters in the datestamp:
             day = day[:-3]
 
             new = "_".join([day, TFILE])
@@ -314,3 +314,41 @@
             os.remove(new)
       #+end_src
 
+    + [X] Preprend the short datestamp (YYMMDD, feature by Reiner Rottmann)
+      Related to the basic pattern, except truncating of the first two
+      characters.
+      #+begin_src python :tangle test_date2name.py
+        @pytest.mark.parametrize("arg1", ["-S", "--short",
+                                          "-S -f", "--short -f",
+                                          "-S --files", "--short --files",
+                                          "-S -m", "--short -m",
+                                          "-S --mtime", "--short --mtime",
+                                          "-S -c", "--short -c",
+                                          "-S --ctime", "--short --ctime"])
+        def test_short_pattern_YYMMDD(arg1):
+            """Prepend 'YYMMDD_' to the file name."""
+            prepare_testfile()
+            day = str("")
+            new = str("")
+        
+            if arg1 in ["-S", "--short",
+                        "-S -f", "--short -f",
+                        "-S --files", "--short --files",
+                        "-S -m", "--short -m",
+                        "-S --mtime", "--short --mtime"]:
+                day = query_file_modification().split()[0]
+        
+            elif arg1 in ["-S -c", "--short -c",
+                          "-S --ctime", "--short --ctime"]:
+                day = query_file_creation().split()[0]
+        
+            # drop the hyphens in the datestamp:
+            day = day.replace("-", "")
+            # drop the first two characters about the year (e.g., 1789 -> 89)
+            day = day[2:]
+        
+            new = "_".join([day, TFILE])
+            test = getoutput(f"python3 {PROGRAM} {TFILE} {arg1}")
+            assert os.path.isfile(new)
+            os.remove(new)
+      #+end_src


### PR DESCRIPTION
The set of tests about date2name's action on files, generated from an .org file
was extended.  The short format (YYMMDD) suggested by Reiner Rottmann
and already present now equally is probed successfully.