### PR TITLE
remove version test on date2name

### DIFF
--- a/test_date2name.py
+++ b/test_date2name.py
@@ -4,7 +4,7 @@
 # author:  nbehrnd@yahoo.com
 # license: GPL v3, 2021.
 # date:    2021-08-30 (YYYY-MM-DD)
-# edit:    2021-09-29 (YYYY-MM-DD)
+# edit:    2021-11-25 (YYYY-MM-DD)
 #
 """Test pad for functions by date2name with pytest.
 
@@ -86,15 +86,6 @@ def test_create_remove_testfolder(name=TFOLDER):
 def test_script_existence():
     """Merely check for the script's presence."""
     assert os.path.isfile(PROGRAM)
-
-
-@pytest.mark.elementary    
-def test_script_version():
-    """Check for the correct output of the version.
-
-    CLI equivalence: date2name --version """
-    out = getoutput(f"python3 {PROGRAM} --version")
-    assert out.strip() == "__init__.py 2018-05-09"
 
 @pytest.mark.files
 @pytest.mark.default

--- a/test_generator.org
+++ b/test_generator.org
@@ -1,6 +1,6 @@
 #+NAME:    test_generator.org
 #+AUTHOR:  nbehrnd@yahoo.com
-#+DATE:    2021-09-29 (YYYY-MM-DD)
+#+DATE:    2021-11-25 (YYYY-MM-DD)
 # License: GPL3, 2021.
 
 #+PROPERTY: header-args :tangle yes
@@ -135,7 +135,7 @@
       # author:  nbehrnd@yahoo.com
       # license: GPL v3, 2021.
       # date:    2021-08-30 (YYYY-MM-DD)
-      # edit:    2021-09-29 (YYYY-MM-DD)
+      # edit:    2021-11-25 (YYYY-MM-DD)
       #
       """Test pad for functions by date2name with pytest.
       
@@ -211,35 +211,26 @@
     #+begin_src python :tangle test_date2name.py
       @pytest.mark.elementary
       def test_create_remove_testfile(name=TFILE):
-          """Merely check if the test file may be written and removed."""
-          prepare_testfile(name=TFILE)
-          assert os.path.isfile(name)
-          os.remove(name)
-          assert os.path.isfile(name) is False
+	  """Merely check if the test file may be written and removed."""
+	  prepare_testfile(name=TFILE)
+	  assert os.path.isfile(name)
+	  os.remove(name)
+	  assert os.path.isfile(name) is False
       
       
       @pytest.mark.elementary    
       def test_create_remove_testfolder(name=TFOLDER):
-          """Probe the generation/removal of a test folder."""
-          prepare_testfolder(name=TFOLDER)
-          assert os.path.isdir(name)
-          os.rmdir(name)
-          assert os.path.isdir(name) is False
+	  """Probe the generation/removal of a test folder."""
+	  prepare_testfolder(name=TFOLDER)
+	  assert os.path.isdir(name)
+	  os.rmdir(name)
+	  assert os.path.isdir(name) is False
       
       
       @pytest.mark.elementary
       def test_script_existence():
-          """Merely check for the script's presence."""
-          assert os.path.isfile(PROGRAM)
-      
-      
-      @pytest.mark.elementary    
-      def test_script_version():
-          """Check for the correct output of the version.
-      
-          CLI equivalence: date2name --version """
-          out = getoutput(f"python3 {PROGRAM} --version")
-          assert out.strip() == "__init__.py 2018-05-09"
+	  """Merely check for the script's presence."""
+	  assert os.path.isfile(PROGRAM)
     #+end_src
 
 


### PR DESCRIPTION
There was a test about the version of `__init.py__`, about the time stamp
explicitly set in this very file.  In the original .org (prior to this update)
this was defined in a block starting on line 236.

I recognize it is better if this test no longer is carried along, perhaps
especially in a collaborative project.  Both .org and tangled .py of this commit
do not include them.