### PR TITLE
account for pytest's call sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # GNU Make file for the automation of pytest for date2name.
 #
-# While the test script is written for Python 3.9.2, you might need to
-# adjust the following instruction once in case your OS includes pytest
-# for legacy Python 2 side by side to Python 3, or only hosts pytest
-# for Python 3.  The tests in script test_date2name.py are set up to
-# work with pytest for Python 3; dependent on your installation, which
-# may be named pytest-3, or (again) pytest.
+# While the test script is written for Python 3.9.2, it depends on
+# your installation of pytest (and in case of Linux, the authors of
+# your distribution) if pytest for Python 3 is invoked either by
+# pytest, or pytest-3.  In some distributions, pytest actually may
+# invoke pyest for legacy Python 2; the tests in test_date2name.py
+# however are incompatible to this.
 #
 # Put this file like test_date2name.py in the root folder of date2name
 # fetched from PyPi or GitHub.  Then run
@@ -17,5 +17,5 @@
 # right after the first test failing, use the -x flag to the
 # instructions on the CLI in addition to the verbosity flag to (-v).
 
-# pytest -v test_date2name.py     # only pytest for Python 3 is present
-pytest-3 -v test_date2name.py   # pytest if Python 2 and Python 3 coexist
+# pytest -v test_date2name.py     # the pattern by pytest's manual
+pytest-3 -v test_date2name.py   # the alternative pattern (e.g., Debian 12)

--- a/test_generator.org
+++ b/test_generator.org
@@ -1,6 +1,6 @@
 #+NAME:    test_generator.org
 #+AUTHOR:  nbehrnd@yahoo.com
-#+DATE:    2022-01-03 (YYYY-MM-DD)
+#+DATE:    2022-01-09 (YYYY-MM-DD)
 # License: GPL3, 2021.
 
 #+PROPERTY: header-args :tangle yes
@@ -18,23 +18,24 @@
 
 * Deployment
 
-  On a computer with Python 3 only, the recommended call on the CLI to run the
-  tests is either one of the following instructions (you might need to add the
-  executable bit):
+  The programmatic tests are set up for pytest for Python 3.  It
+  however depends on your installation (and in case of Linux, the
+  authors of your Linux distribution ([[https://github.com/pytest-dev/pytest/discussions/9481][reference]])) if this utility may
+  be started by =pytest= (e.g., the pattern in pytest's manual), or by
+  =pytest-3= by either one of the pattern below:
 
   #+begin_src bash :tangle no
-  python pytest -v test_date2name.py
-  ./Makefile
+pytest -v test_date2name.py
+pytest-3 -v test_date2name.py
   #+end_src
 
-  In case the computer you use equally includes an installation of legacy
-  Python 2 side-by-side to Python 3, you must explicitly call for the later
-  branch of the two.  Depending on your OS, this requires an adjustment of the
-  command issued.  In Linux Debian 12/bookworm, branch testing, for example,
+  As of writing, the later pattern is the to be used e.g., in Linux
+  Debian 12/bookworm (branch testing) to discern pytest (for
+  contemporary Python 3) from pytest (for legacy Python 2).
 
-  #+begin_src bash :tangle no
-  python3 pytest-3 -v test_date2name.py
-  #+end_src
+  The =Makefile= this =org= file provides for convenience running
+  these tests assumes the later syntax pattern.  (It might be
+  necessary to provide the executable bit to activate the Makefile.)
 
 * Setup of Emacs
 
@@ -102,12 +103,12 @@
     #+BEGIN_SRC makefile :tangle Makefile
 # GNU Make file for the automation of pytest for date2name.
 #
-# While the test script is written for Python 3.9.2, you might need to
-# adjust the following instruction once in case your OS includes pytest
-# for legacy Python 2 side by side to Python 3, or only hosts pytest
-# for Python 3.  The tests in script test_date2name.py are set up to
-# work with pytest for Python 3; dependent on your installation, which
-# may be named pytest-3, or (again) pytest.
+# While the test script is written for Python 3.9.2, it depends on
+# your installation of pytest (and in case of Linux, the authors of
+# your distribution) if pytest for Python 3 is invoked either by
+# pytest, or pytest-3.  In some distributions, pytest actually may
+# invoke pyest for legacy Python 2; the tests in test_date2name.py
+# however are incompatible to this.
 #
 # Put this file like test_date2name.py in the root folder of date2name
 # fetched from PyPi or GitHub.  Then run
@@ -119,8 +120,8 @@
 # right after the first test failing, use the -x flag to the
 # instructions on the CLI in addition to the verbosity flag to (-v).
 
-# pytest -v test_date2name.py     # only pytest for Python 3 is present
-pytest-3 -v test_date2name.py   # pytest if Python 2 and Python 3 coexist
+# pytest -v test_date2name.py     # the pattern by pytest's manual
+pytest-3 -v test_date2name.py   # the alternative pattern (e.g., Debian 12)
     #+end_src
 
 ** Building a pytest.ini


### PR DESCRIPTION
The clarification by pytest's developers about calling the checker by `pytest` or `pytest-3` is echoed.