### PR TITLE
fix() decrement-Python-dependency-to-v3.9+, update-dates

### DIFF
--- a/date2name/__init__.py
+++ b/date2name/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-PROG_VERSION = u"Time-stamp: <2022-01-10 12:56:17 vk>"
+PROG_VERSION = u"Time-stamp: <2024-04-25>"
 
 """
 date2name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ date2name="date2name:main"
 
 [tool.poetry]
 name = "date2name"
-version = "2024.03.10.1"
+version = "2024.04.25.1.309"
 description = "Handling time-stamps and date-stamps in file names"
 authors = ["Karl Voit <tools@Karl-Voit.at>"]
 license = "GPL v3"
 readme = "README.org"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The previous setup defined by `pyproject.toml` required Python 3.11 as minimal version, hence excluding the installation of `date2name` with older editions of Python.  Because the utility exclusively uses modules of Python's standard library (checked with `pipreqs`, version 0.4.13), the threshold was lowered to Python 3.9+ instead.  Released on 2020-10-05, its end of support is scheduled for 2025-10.[1]

In addition, a few internal date stamps were updated gently.

[1] https://www.python.org/downloads/