### PR TITLE
Fix Python 3.12 SyntaxWarning

### DIFF
--- a/date2name/__init__.py
+++ b/date2name/__init__.py
@@ -30,14 +30,14 @@ FORMATSTRING_STANDARD = "%Y-%m-%d"
 FORMATSTRING_MONTH    = "%Y-%m"
 FORMATSTRING_WITHTIME = "%Y-%m-%dT%H.%M.%S"
 REGEX_PATTERNS = {
-    'NODATESTAMP': re.compile('^\D'),
-    'SHORT': re.compile('^(\d{2})([01]\d)([0123]\d)([- _])'),
-    'COMPACT': re.compile('^(\d{4})([01]\d)([0123]\d)([- _])'),
-    'STANDARD': re.compile('^(\d{4})-([01]\d)-([0123]\d)([- _])'),
-    'MONTH': re.compile('^(\d{4})-([01]\d)(?!-[0123]\d)([- _])'),
-    'WITHTIME_AND_SECONDS': re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _.])'),
-    'WITHTIME_NO_SECONDS':  re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([- _.])'),
-    'WITHSECONDS': re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _])'),
+    'NODATESTAMP': re.compile(r'^\D'),
+    'SHORT': re.compile(r'^(\d{2})([01]\d)([0123]\d)([- _])'),
+    'COMPACT': re.compile(r'^(\d{4})([01]\d)([0123]\d)([- _])'),
+    'STANDARD': re.compile(r'^(\d{4})-([01]\d)-([0123]\d)([- _])'),
+    'MONTH': re.compile(r'^(\d{4})-([01]\d)(?!-[0123]\d)([- _])'),
+    'WITHTIME_AND_SECONDS': re.compile(r'^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _.])'),
+    'WITHTIME_NO_SECONDS':  re.compile(r'^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([- _.])'),
+    'WITHSECONDS': re.compile(r'^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _])'),
 }
 MAX_PATHLENGTH = 255  # os.pathconf('/', 'PC_PATH_MAX') may be longer but os.rename() seems to have hard-coded 256
 


### PR DESCRIPTION
This PR addresses `SyntaxWarnings` caused by invalid escape sequences in string literals.

Python 3.12 upgraded these warnings from `DeprecationWarnings` introduced in [Python 3.6](https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior) to `SyntaxWarnings`, making them visible by default.
These warnings indicate that escape sequences (like \d) are being used incorrectly.
The simplest fix is using raw strings (e.g., r"\d") to prevent escape sequence processing.
In future python versions, these syntax warnings will become errors.

```
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:33: SyntaxWarning: invalid escape sequence '\D'
  'NODATESTAMP': re.compile('^\D'),                                                                                                           
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:34: SyntaxWarning: invalid escape sequence '\d'
  'SHORT': re.compile('^(\d{2})([01]\d)([0123]\d)([- _])'),                                                                                   
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:35: SyntaxWarning: invalid escape sequence '\d'  
  'COMPACT': re.compile('^(\d{4})([01]\d)([0123]\d)([- _])'),                                                                                 
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:36: SyntaxWarning: invalid escape sequence '\d'
  'STANDARD': re.compile('^(\d{4})-([01]\d)-([0123]\d)([- _])'),                                                                              
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:37: SyntaxWarning: invalid escape sequence '\d'  
  'MONTH': re.compile('^(\d{4})-([01]\d)(?!-[0123]\d)([- _])'),
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:38: SyntaxWarning: invalid escape sequence '\d'  
  'WITHTIME_AND_SECONDS': re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _.])'),
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:39: SyntaxWarning: invalid escape sequence '\d'  
  'WITHTIME_NO_SECONDS':  re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([- _.])'),                            
/home/kai/.local/share/uv/tools/date2name/lib/python3.12/site-packages/date2name/__init__.py:40: SyntaxWarning: invalid escape sequence '\d'  
  'WITHSECONDS': re.compile('^(\d{4})-([01]\d)-([0123]\d)([T :_-])([012]\d)([:.-])([012345]\d)([:.-])([012345]\d)([- _])'),  
```