### PR TITLE
build(pyproject.toml): correct omission of `name`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 
 [project]
+name = "date2name"
 readme = "README.org"
 keywords = ["file managing", "file management", "files", "date", "time", "time-stamps"]
 classifiers=[


### PR DESCRIPTION
The creation of a Python wheel with `python -m build` was impossible because the project section previously omitted the `name` parameter.